### PR TITLE
Add New Theme Monokai Dark Soda and Fix Menu Bug

### DIFF
--- a/main.js
+++ b/main.js
@@ -84,7 +84,7 @@ define(function (require, exports, module) {
     *  Then takes all first letters and capitalizes them.
     */
     theme.toDisplayName = function (name) {
-        name = name.substring(0, name.lastIndexOf('.')).replace('-', ' ');
+        name = name.substring(0, name.lastIndexOf('.')).replace(/-/g, ' ');
         var parts = name.split(" ");
 
         $.each(parts.slice(0), function (index, part) {
@@ -380,4 +380,3 @@ define(function (require, exports, module) {
     });
 
 });
-

--- a/theme/monokai-dark-soda.css
+++ b/theme/monokai-dark-soda.css
@@ -1,0 +1,51 @@
+.cm-s-monokai-dark-soda.CodeMirror {
+	background-color: #242424;
+	color: #fff;
+}
+
+.CodeMirror div.CodeMirror-cursor {
+  border-left: 1px solid #f8f8f0;
+  z-index: 3;
+}
+
+.CodeMirror-selected { 
+    background: #3d3d3d;
+    opacity: .23; 
+}
+
+.cm-s-monokai-dark-soda .cm-keyword {color: #ff007f;}
+.cm-s-monokai-dark-soda .cm-atom {color: #c48cff;}
+.cm-s-monokai-dark-soda .cm-number {color: #c48cff;}
+.cm-s-monokai-dark-soda .cm-def {color: #fd963f;}
+.cm-s-monokai-dark-soda .cm-variable {color: #fff;}
+.cm-s-monokai-dark-soda .cm-variable-2 {color: #c48cff;}
+.cm-s-monokai-dark-soda .cm-property {color: #52e3f6;}
+.cm-s-monokai-dark-soda .cm-operator {color: #ff007f;}
+.cm-s-monokai-dark-soda .cm-comment {color: #8c8c8c;}
+.cm-s-monokai-dark-soda .cm-string {color: #ece47e;}
+.cm-s-monokai-dark-soda .cm-string-2 {color: #ece47e;}
+.cm-s-monokai-dark-soda .cm-meta {color: #a7ec21;}
+.cm-s-monokai-dark-soda .cm-qualifier {color: #a7ec21;}
+.cm-s-monokai-dark-soda .cm-bracket {color: #f9faf4;}
+.cm-s-monokai-dark-soda .cm-tag {color: #ff007f;}
+.cm-s-monokai-dark-soda .cm-attribute {color: #a7ec21;}
+
+.cm-s-monokai-dark-soda .cm-matchhighlight {background-color: rgba(61,61,61.23);}
+
+div.CodeMirror span.CodeMirror-matchingbracket {
+    color: #a7ec21;
+    font-weight: bold;
+}
+
+
+div.CodeMirror span.CodeMirror-searching {
+  background-color: none;
+  background: none;
+  box-shadow: 0 0 0 1px #fff;
+}
+
+
+div.CodeMirror span.cm-matchhighlight.CodeMirror-searching.CodeMirror-selectedtext {
+    background-color: #ffe69d;
+    color: #242424;
+}


### PR DESCRIPTION
Add new theme, Monokai Dark Soda, inspired by a Sublime Text 2 theme by [mrlundis](https://github.com/mrlundis/Monokai-Dark-Soda.tmTheme) that I really enjoyed and missed.

Also fixed a `replace` bug where not all hyphens were being replaced if more than one was used for the theme's Theme menu item.

![image](https://f.cloud.github.com/assets/1106234/389241/b1fab986-a6fb-11e2-8235-02baa99b2e17.png)
