### PR TITLE
Fix for issue #5

### DIFF
--- a/main.js
+++ b/main.js
@@ -134,18 +134,25 @@ define(function (require, exports, module) {
     */
     themeManager.applyThemes = function () {
         var editor = EditorManager.getActiveEditor();
+        
         if (!editor || !editor._codeMirror) {
             return;
         }
-
+        
         var cm = editor._codeMirror;
         var themesString = themeManager._selection.join(" ");
-
+        
         // Check if the editor already has the theme applied...
         if (cm.getOption("theme") === themesString) {
+            var mainEditor = EditorManager.getCurrentFullEditor();
+            if (editor !== mainEditor) {
+                setTimeout(function(){
+                    EditorManager.resizeEditor(EditorManager.REFRESH_FORCE);
+                }, 100);
+            }
             return;
         }
-
+        
         // Setup current and further documents to get the new theme...
         CodeMirror.defaults.theme = themesString;
         cm.setOption("theme", themesString);


### PR DESCRIPTION
I'm not thrilled with this solution but it does work.

Using the setTimeout() again is a hack but I haven't been able to figure out why the editor resizing requires a time delay to work.  It must be some sort of asynchronous operation, perhaps with the way the themes are loaded.

If I see this issue pop up again, I will dig deeper into a better solution, but this does work for now. 
