### PR TITLE
Addressed highlighting concerns in every theme.

### DIFF
--- a/reset.css
+++ b/reset.css
@@ -44,7 +44,139 @@
 * Overrides for CodeMirror themes.
 */
 
-.CodeMirror.cm-s-the-matrix .CodeMirror-matchingtag
-{
-   background: rgba(0,255,0,0.3);
+.CodeMirror.cm-s-light-table .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-monokai-dark-soda .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-nando .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-obsidian .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+
+.CodeMirror.cm-s-pixie .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-visual-studio-ex .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 1);
+}
+
+.CodeMirror.cm-s-visual-studio .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 1);
+}
+
+.CodeMirror.cm-s-zamiere .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-3024-day .CodeMirror-matchingtag {
+background: rgba(93, 212, 124, 0.78);
+}
+
+.CodeMirror.cm-s-3024-night .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-ambiance .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-base16-dark .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.1);
+}
+
+.CodeMirror.cm-s-base16-light .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.7);
+}
+
+.CodeMirror.cm-s-blackboard .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-cobalt .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-eclipse .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 1);
+}
+
+.CodeMirror.cm-s-elegant .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 1);
+}
+
+.CodeMirror.cm-s-erlang-dark .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-lesser-dark .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-mbo .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-midnight .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.1);
+}
+
+.CodeMirror.cm-s-monokai .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.1);
+}
+
+.CodeMirror.cm-s-neat .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 1);
+}
+
+.CodeMirror.cm-s-night .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-paraiso-dark .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-paraiso-light .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 1);
+}
+
+.CodeMirror.cm-s-rubyblue .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-solarized.CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 1);
+}
+
+.CodeMirror.cm-s-the-matrix .CodeMirror-matchingtag {
+background: rgba(0, 255, 0, 0.3);
+}
+
+.CodeMirror.cm-s-tomorrow-night-eighties .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-twilight .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-vibrant-ink .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.3);
+}
+
+.CodeMirror.cm-s-xq-dark .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 0.2);
+}
+
+.CodeMirror.cm-s-xq-light .CodeMirror-matchingtag {
+background: rgba(207, 234, 214, 1);
 }


### PR DESCRIPTION
The update is intended to be verbose so as to provide as much opportunity for individual tweaking as possible. 

In every case opacity has been added to the background-color to dim (or enhance) the brightness of the highlight. 

The pixie theme currently runs into: background-color: #222222 !important; in the pixie-css:135 meaning it doesnt currently display.
